### PR TITLE
mesa3d: -Ddri-drivers= is not needed anymore

### DIFF
--- a/meson_mesa3d.mk
+++ b/meson_mesa3d.mk
@@ -25,7 +25,6 @@ MESA_VK_LIB_SUFFIX_swrast := lvp
 MESON_BUILD_ARGUMENTS := \
     -Dplatforms=android                                                          \
     -Dplatform-sdk-version=$(PLATFORM_SDK_VERSION)                               \
-    -Ddri-drivers=                                                               \
     -Dgallium-drivers=$(subst $(space),$(comma),$(BOARD_MESA3D_GALLIUM_DRIVERS)) \
     -Dvulkan-drivers=$(subst $(space),$(comma),$(subst radeon,amd,$(BOARD_MESA3D_VULKAN_DRIVERS)))   \
     -Dgbm=enabled                                                                \


### PR DESCRIPTION
Based on: https://gitlab.freedesktop.org/mesa/mesa/-/commit/5ae744c5982f9196907dbdabaed2ae0d14c31afd
Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>