### PR TITLE
Fix compilation errors on some Linux distributions

### DIFF
--- a/aospext_cross_compile.mk
+++ b/aospext_cross_compile.mk
@@ -121,6 +121,6 @@ $(AOSPEXT_INTERNAL_BUILD_TARGET): $(AOSP_FLAGS_DIR_OUT)/.sharedlib.timestamp
 		$(AOSPEXT_ABS_OUT_DIR)/project_specific.mk
 
 	# Build project
-	export $$(cat /etc/environment):$(RUST_BIN_DIR_ABS):$(AOSP_ABSOLUTE_PATH)/$(LLVM_PREBUILTS_PATH) && make -C $(AOSPEXT_ABS_OUT_DIR) install
+	export PATH=$(RUST_BIN_DIR_ABS):$(AOSP_ABSOLUTE_PATH)/$(LLVM_PREBUILTS_PATH):$$(cat $(OUT_DIR)/.path_interposer_origpath) && make -C $(AOSPEXT_ABS_OUT_DIR) install
 
 	touch $@


### PR DESCRIPTION
Using the /etc/environment to obtain the path works on Ubuntu, but it does not work for some Linux distros. Use out/.path_interposer_origpath instead.