### PR TITLE
tools/wrapper.sh: filter out -lstdc++ in ARGS to avoid mesa 24.2 building error

### DIFF
--- a/tools/wrapper.sh
+++ b/tools/wrapper.sh
@@ -47,6 +47,7 @@ ARGS="${ARGS//-ldl/}"
 ARGS="${ARGS//-lgcc/}"
 ARGS="${ARGS//-llog/}"
 ARGS="${ARGS//-lm/}"
+ARGS="${ARGS//-lstdc++/}"
 ARGS="${ARGS//-lunwind/}"
 
 ARGS="${ARGS/\[C_ARGS\]/${CFLAGS}}"


### PR DESCRIPTION
Fixes the following meson building error happening at mesa 24.2 build:

ERROR: Could not detect either libc++ or libstdc++ as your C++ stdlib implementation.