### PR TITLE
tools/wrapper.sh: filter out -lc++ in ARGS to avoid mesa 24.2 building error

### DIFF
--- a/tools/wrapper.sh
+++ b/tools/wrapper.sh
@@ -42,6 +42,7 @@ fi
 
 # Filter-out libraries, since we're not using NDK but adding .so directly
 ARGS="${ARGS//-lc++_shared/}"
+ARGS="${ARGS//-lc++/}"
 ARGS="${ARGS//-lc/}"
 ARGS="${ARGS//-ldl/}"
 ARGS="${ARGS//-lgcc/}"


### PR DESCRIPTION
New filter out required, the order matters due existing -lc++_shared and -lc

Fixes the following meson building error happening at mesa 24.2 build:

ERROR: Could not detect either libc++ or libstdc++ as your C++ stdlib implementation.

meson-log.txt hints the root cause of the new problem:

-----------
Command line: `/media/bigblissdrive/u-x86_michael_ax86/out/target/product/android_x86_64/obj/AOSPEXT/MESA3D/toolchain_wrapper/wrap_clang++ /media/bigblissdrive/u-x86_michael_ax86/out/target/product/android_x86_64/obj/AOSPEXT/MESA3D/build/meson-private/tmpen_0x9ae/testfile.cpp -o /media/bigblissdrive/u-x86_michael_ax86/out/target/product/android_x86_64/obj/AOSPEXT/MESA3D/build/meson-private/tmpen_0x9ae/output.exe '[CPP_ARGS]' -D_FILE_OFFSET_BITS=64 -O0 -fpermissive -Werror=implicit-function-declaration -lc++ -fuse-ld=lld -Wl,--allow-shlib-undefined -fuse-ld=lld '[C_LINK_ARGS]'` -> 1 stderr:
clang++: error: no such file or directory: '++'
-----------