### PR TITLE
drm_hwcomposer: Add libdisplay_info dependency

### DIFF
--- a/meson_drmhwcomposer.mk
+++ b/meson_drmhwcomposer.mk
@@ -18,6 +18,11 @@ LOCAL_HEADER_LIBRARIES :=
 LOCAL_SHARED_LIBRARIES := libbase libcutils libdrm libhardware libhidlbase liblog libsync libui libutils
 AOSPEXT_GEN_PKGCONFIGS := base cutils drm hardware hidlbase log sync ui utils
 
+ifneq ($(wildcard external/libdisplay_info),)
+LOCAL_STATIC_LIBRARIES += libdisplay_info
+AOSPEXT_GEN_PKGCONFIGS += display_info
+endif
+
 MESON_BUILD_ARGUMENTS := \
 
 # Format: TYPE:REL_PATH_TO_INSTALL_ARTIFACT:VENDOR_SUBDIR:MODULE_NAME:SYMLINK_SUFFIX


### PR DESCRIPTION
The [libdisplay_info][1] provides EDID parsing functions.

[1]: https://android.googlesource.com/platform/external/libdisplay-info/
