### PR TITLE
drm_hwcomposer: Add AIDL version 4

### DIFF
--- a/meson_drmhwcomposer.mk
+++ b/meson_drmhwcomposer.mk
@@ -56,8 +56,10 @@ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -le 33; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += android.hardware.graphics.composer3-V1-ndk
 else ifeq ($(shell test $(PLATFORM_SDK_VERSION) -le 34; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += android.hardware.graphics.composer3-V2-ndk
-else
+else ifeq ($(shell test $(PLATFORM_SDK_VERSION) -le 35; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += android.hardware.graphics.composer3-V3-ndk
+else
+LOCAL_SHARED_LIBRARIES += android.hardware.graphics.composer3-V4-ndk
 endif
 
 endif


### PR DESCRIPTION
Add support for AIDL version 4 so that drm-hwcomposer can build with PLATFORM_SDK_VERSION 36 for Android 16.